### PR TITLE
Remove debugging comment

### DIFF
--- a/share/hcp2blocks.m
+++ b/share/hcp2blocks.m
@@ -271,7 +271,7 @@ for f = 1:numel(F),
                 end
             end
             if k == 2,
-                tab(fidx,1:4)
+                tab(fidx,1:4);
                 famtype(fidx) = 49;
                 B{f}(:,1) = -B{f}(:,1);
             end

--- a/share/hcp2blocks.m
+++ b/share/hcp2blocks.m
@@ -271,7 +271,6 @@ for f = 1:numel(F),
                 end
             end
             if k == 2,
-                tab(fidx,1:4);
                 famtype(fidx) = 49;
                 B{f}(:,1) = -B{f}(:,1);
             end


### PR DESCRIPTION
There was one line that generated a 4-row matrix, presumably for debugging.  This removes that.